### PR TITLE
[security] Disable Apache2 mod_status across HAXiam install scripts

### DIFF
--- a/scripts/install/ubuntu20.04.sh
+++ b/scripts/install/ubuntu20.04.sh
@@ -43,6 +43,7 @@ sudo a2enmod ssl
 sudo a2enmod rewrite
 sudo a2enmod headers
 sudo a2enmod brotli
+sudo a2dismod status
 # enable protocol support
 echo "Protocols h2 http/1.1" > /etc/apache2/conf-available/http2.conf
 sudo a2enconf http2

--- a/scripts/install/ubuntu22.04.sh
+++ b/scripts/install/ubuntu22.04.sh
@@ -47,6 +47,7 @@ sudo a2enmod ssl
 sudo a2enmod rewrite
 sudo a2enmod headers
 sudo a2enmod brotli
+sudo a2dismod status
 
 # Enable protocol support
 echo "Protocols h2 http/1.1" > /etc/apache2/conf-available/http2.conf

--- a/scripts/install/ubuntu24.04.sh
+++ b/scripts/install/ubuntu24.04.sh
@@ -41,6 +41,7 @@ sudo a2enmod ssl
 sudo a2enmod rewrite
 sudo a2enmod headers
 sudo a2enmod brotli
+sudo a2dismod status
 
 # Enable protocol support
 sudo -i


### PR DESCRIPTION
## New Features
* Disables Apache2 `status` module for all PHP-based HAXiam deployments
    * On several Linux distributions, the Apache2 package has its `status` module enabled by default
    * There's the potential to leak system data like: logs, users, URLs, and even local file paths

## Related Issue(s)
* https://github.com/haxtheweb/issues/issues/2627